### PR TITLE
Speed part 2

### DIFF
--- a/src/OpenAIGym.jl
+++ b/src/OpenAIGym.jl
@@ -1,6 +1,8 @@
 module OpenAIGym
 
 using PyCall
+using PyCall: setdata!
+
 using Reexport
 @reexport using Reinforce
 import Reinforce:
@@ -137,7 +139,7 @@ convert_state!(env::GymEnv{T}) where T =
     env.state = convert(T, env.pystate)
 
 convert_state!(env::GymEnv{<:PyArray}) =
-    env.state = PyArray(env.pystate)
+    setdata!(env.state, env.pystate)
 
 Reinforce.finished(env::GymEnv)     = env.done
 Reinforce.finished(env::GymEnv, s′) = env.done


### PR DESCRIPTION
Uses `setdata!` from https://github.com/JuliaPy/PyCall.jl/pull/487 which just updates the pointer to the data of the env.state PyArray, rather than creating a new PyArray each step.

requires 
* ~https://github.com/JuliaML/Reinforce.jl/pull/23~ (merged)
* https://github.com/JuliaPy/PyCall.jl/pull/487 (merged, awaiting release)

This is just one extra small commit on top of #11 