### PR TITLE
Reinforce v0.2 compatible

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Reinforce = "0376cc21-f8a9-5fcf-8891-fde1415a4fd3"
 
 [compat]
-Reinforce = "~0.1"
+Reinforce = "~0.2"
 julia = "≥0.7"
 
 [extras]


### PR DESCRIPTION
OpenAIGym.jl could not be added on Julia v1.0.2+ due to compatibility issues of Julia version with Reinforce v0.1, hence the changes.