### PR TITLE
add compatibility with last version of Reinforce

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Reinforce = "0376cc21-f8a9-5fcf-8891-fde1415a4fd3"
 
 [compat]
-Reinforce = "~0.2, 0.3.0"
+Reinforce = "0.2, 0.3"
 julia = "≥0.7"
 PyCall = "≥1.90.0"
 

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Reinforce = "0376cc21-f8a9-5fcf-8891-fde1415a4fd3"
 
 [compat]
-Reinforce = "~0.2"
+Reinforce = "~0.2, 0.3.0"
 julia = "≥0.7"
 PyCall = "≥1.90.0"
 


### PR DESCRIPTION
Reinforce.jl recently upgraged to 0.3.0 with a fixed issue making the precompiling impossible. It's hence necessary to add the compatibility. (issue #36)