### PR TITLE
Fix IntervalSet issue

### DIFF
--- a/src/OpenAIGym.jl
+++ b/src/OpenAIGym.jl
@@ -8,6 +8,9 @@ import Reinforce:
     MouseAction, MouseActionSet,
     KeyboardAction, KeyboardActionSet
 
+import Reinforce.Learnbase:
+    IntervalSet
+
 export
     GymEnv,
     render,

--- a/src/OpenAIGym.jl
+++ b/src/OpenAIGym.jl
@@ -8,7 +8,7 @@ import Reinforce:
     MouseAction, MouseActionSet,
     KeyboardAction, KeyboardActionSet
 
-import Reinforce.Learnbase:
+import Reinforce.LearnBase:
     IntervalSet
 
 export


### PR DESCRIPTION
Currently there's a bug on master where Reinforce.LearnBase.IntervalSet is not available when using the package. This PR explicitly imports IntervalSet to address the issue.

There's likely a neater way to accomplish this, but at least the ball is rolling now