### PR TITLE
add missing import for DiscreteSet

### DIFF
--- a/src/OpenAIGym.jl
+++ b/src/OpenAIGym.jl
@@ -9,7 +9,7 @@ import Reinforce:
     KeyboardAction, KeyboardActionSet
 
 import Reinforce.LearnBase:
-    IntervalSet
+    IntervalSet, DiscreteSet
 
 export
     GymEnv,


### PR DESCRIPTION
It seems the import for DiscreteSet is missing, which caused below error:

[ Info: Precompiling OpenAIGym [41d6fcb8-dd24-11e8-2536-c3dc023218b5]
ERROR: LoadError: UndefVarError: DiscreteSet not defined